### PR TITLE
Update the start SQL server (Docker) command

### DIFF
--- a/samples/2023-11-todo-ef/readme.md
+++ b/samples/2023-11-todo-ef/readme.md
@@ -28,7 +28,7 @@ dotnet add package Microsoft.EntityFrameworkCore.SqlServer
 If you want to run SQL Server locally on Linux, you can use Docker.
 
 ```bash
-docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=MyStr0ngPazzword" -e "MSSQL_PID=Express" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2019-latest
+docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=MyStr0ngPazzword" -e "MSSQL_PID=Express" -p 127.0.0.1:1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
 ```
 
 ## SQL Server (Windows)


### PR DESCRIPTION
During our last lesson, if found out that the MSSQL server 2022 is already released. Furthermore, the Docker port mapping exposes services to the public by default, which might not be ideal for a local dev database. You can find additional information about the port mapping "problem" in the [official Docker documentation](https://docs.docker.com/network/#published-ports), especially in the red info box.